### PR TITLE
Fix depguard lint by adding explicit deny list

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ stages:
   - deploy
 
 lint:
-  image: golangci/golangci-lint:v1.51.0
+  image: golangci/golangci-lint:v1.59.1
   stage: test
   before_script:
     - cp .env.testing.gitlab-ci .env.testing

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,21 +14,22 @@ linters-settings:
       - opinionated
       - performance
       - style
-    enable-checks:
+    enabled-checks:
       - whyNoLint
     disabled-checks:
       - dupImport # https://github.com/go-critic/go-critic/issues/845
   gocyclo:
     min-complexity: 15
-  golint:
-    min-confidence: 0
-  gomnd:
-    settings:
-      mnd:
-        # don't include the "operation" and "assign"
-        checks: argument,case,condition,return
+  revive:
+    confidence: 0
+  mnd:
+    checks:
+      # don't include the "operation" and "assign"
+      - argument
+      - case
+      - condition
+      - return
   govet:
-    check-shadowing: true
     settings:
       printf:
         funcs:
@@ -38,12 +39,19 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
   lll:
     line-length: 140
-  maligned:
-    suggest-new: true
   misspell:
     locale: US
-  nolint:
+  nolintlint:
     require-explanation: true
+  depguard:
+    rules:
+      prevent_unmaintained_packages:
+        list-mode: lax # allow unless explicitly denied
+        deny:
+          - pkg: io/ioutil
+            desc: "Replaced by io and os packages since Go 1.16: https://tip.golang.org/doc/go1.16#ioutil"
+          - pkg: github.com/pkg/errors
+            desc: "Deprecated: error wrapping available in standard library since Go 1.13"
 
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.
@@ -63,7 +71,7 @@ linters:
     - gofmt
     - goimports
     - revive
-    - gomnd
+    - mnd
     - goprintffuncname
     - gosec
     - gosimple
@@ -89,9 +97,12 @@ linters:
   # - prealloc
 
 run:
-  skip-dirs:
+  tests: false
+
+issues:
+  exclude-dirs:
     - tests
     - migrations/list
 
 service:
-  golangci-lint-version: 1.51.0
+  golangci-lint-version: 1.59.1

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 lint_docker_compose_file = "./development/golangci_lint/docker-compose.yml"
 
 lint-build:
-	@echo "🌀 ️container are building..."
+	@echo "🌀 ️container is building..."
 	@docker-compose --file=$(lint_docker_compose_file) build -q
 	@echo "✔  ️container built"
 
 lint-check:
 	@echo "🌀️ code linting..."
-	@docker-compose --file=$(lint_docker_compose_file) run --rm echo-golinter golangci-lint run \
+	@docker-compose --file=$(lint_docker_compose_file) run --rm echo-golinter golangci-lint version && golangci-lint run \
  		&& echo "✔️  checked without errors" \
  		|| echo "☢️  code style issues found"
 

--- a/development/golangci_lint/Dockerfile
+++ b/development/golangci_lint/Dockerfile
@@ -1,4 +1,4 @@
-FROM golangci/golangci-lint:v1.54.2
+FROM golangci/golangci-lint:v1.59.1
 
 WORKDIR /app
 

--- a/server/routes/routes.go
+++ b/server/routes/routes.go
@@ -32,7 +32,7 @@ func ConfigureRoutes(server *s.Server) {
 	r := server.Echo.Group("")
 	// Configure middleware with the custom claims type
 	config := echojwt.Config{
-		NewClaimsFunc: func(c echo.Context) jwt.Claims {
+		NewClaimsFunc: func(_ echo.Context) jwt.Claims {
 			return new(token.JwtCustomClaims)
 		},
 		SigningKey: []byte(server.Config.Auth.AccessSecret),


### PR DESCRIPTION
### What has been done:

- Upgraded golangci-lint version from `v1.51.0` to `v1.59.1`
- Fixed `golangci.yml` (did not add anything and did not remove anything. Only fix)
- Currently `depguard` lint is complaining for every third party package we use. So I configured it only to disallow only explicitly listed packages 