### PR TITLE
badges added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 <h1 align="center">Welcome to <span style="color:mediumseagreen">Echo boilerplate</span> 👋</h1>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/golang-v1.21-lightblue" height="25"/>
-  <img src="https://img.shields.io/badge/echo-v4.11-blue" height="25"/>
+  <img src="https://img.shields.io/github/go-mod/go-version/nix-united/golang-echo-boilerplate" height="25"/>
   <img src="https://img.shields.io/badge/gorm-v1.25-green" height="25"/>
   <img src="https://img.shields.io/badge/swagger-v1.16-orange" height="25"/>
-  <img src="https://img.shields.io/badge/gin--jwt-v2.9-yellow" height="25"/>
+  <img src="https://img.shields.io/badge/echo-v4.13-yellow" height="25"/>
   <img src="https://img.shields.io/badge/docker-support-darkgreeen" height="25"/>
+  <img src="https://goreportcard.com/badge/github.com/nix-united/golang-echo-boilerplate?style=flat" height="25" />
+  <img src="https://img.shields.io/github/actions/workflow/status/nix-united/golang-echo-boilerplate/ci.yml" height="25"/>
+  <img src="https://img.shields.io/github/checks-status/nix-united/golang-echo-boilerplate/master?label=CI checks" height="25"/>
+  <img src="https://img.shields.io/github/license/nix-united/golang-echo-boilerplate?style=flat&color=blue" height="25" />
 </p>
 
 It's an API Skeleton project based on Echo framework.


### PR DESCRIPTION
### 🎫 Ticket Reference
https://trello.com/c/0CBnoUOS/22-add-versions-for-echo-and-gin

### 📝 Changes
I have added a few badges to our README.md file.

- Go version is fetched automatically from go.mod file.

- However, dependencies cannot be fetched from go.mod file dynamically like go version we are fetching. One way is to create an endpoint where we store the versions and fetch the versions from that API. Any opinions?

- Added goreportcard
- Added build status
- Added CI check status
- Added license

It would be great if would also tell me what we can add here. 